### PR TITLE
Canvas.wrapper: only try to drop if data was emitted

### DIFF
--- a/src/components/Canvas/Canvas.wrapper.tsx
+++ b/src/components/Canvas/Canvas.wrapper.tsx
@@ -100,11 +100,13 @@ export class CanvasWrapper extends React.Component<ICanvasWrapperProps, IState> 
               }}
               onDrop={ (e) => {
                 const data = JSON.parse(e.dataTransfer.getData(REACT_FLOW_CHART))
-                onCanvasDrop({ data, position: {
-                  x: e.clientX - (position.x + offsetX),
-                  y: e.clientY - (position.y + offsetY),
-                }})
-              } }
+                if (data) {
+                  onCanvasDrop({ data, position: {
+                    x: e.clientX - (position.x + offsetX),
+                    y: e.clientY - (position.y + offsetY),
+                  }})
+                } }
+              }
               onDragOver={(e) => e.preventDefault()}
             />
           </Draggable>


### PR DESCRIPTION
We want to drag and drop nodes _inside_ of other nodes. 

As is, we have to emit data to REACT_FLOW_CHART, which adds the node to the canvas. It's also tedious to find the newest nodeId as they're stored in a dictionary/object and thus are not ordered and could share configuration (be deep equal). If we try to not set REACT_FLOW_CHART, we get a JSON parsing error. 

This commit only attempts to create a new node if REACT_FLOW_CHART was actually set, which shouldn't break existing functionality.
