### PR TITLE
Update port position when state changes

### DIFF
--- a/src/components/Port/Port.wrapper.tsx
+++ b/src/components/Port/Port.wrapper.tsx
@@ -45,19 +45,15 @@ export class PortWrapper extends React.Component<IPortWrapperProps> {
 
   private nodeRef = React.createRef<HTMLDivElement>()
 
+  public componentDidMount () {
+    this.updatePortPosition()
+  }
+
   public componentDidUpdate (prevProps: IPortWrapperProps) {
-    // Update port position after a re-render if node.size has changed
-    if (!isEqual(this.props.node.size, prevProps.node.size)) {
-      const el = ReactDOM.findDOMNode(this.nodeRef.current) as HTMLInputElement
-      if (el) {
-        // Ports component should be positions absolute
-        // Factor this in so we get position relative to the node
-        const nodesEl = el.parentElement
-          ? el.parentElement
-          : { offsetLeft: 0, offsetTop: 0 }
-        // update port position after node size has been determined
-        this.props.onPortPositionChange({ config: this.props.config, node: this.props.node, port: this.props.port, el, nodesEl })
-      }
+    // Update port position after a re-render if there are more ports on the same side
+    // or if node.size has changed
+    if (this.portsOfType(this.props) !== this.portsOfType(prevProps) || !isEqual(this.props.node.size, prevProps.node.size)) {
+      this.updatePortPosition()
     }
   }
 
@@ -160,5 +156,23 @@ export class PortWrapper extends React.Component<IPortWrapperProps> {
         />
       </div>
     )
+  }
+
+  private updatePortPosition () {
+    const el = ReactDOM.findDOMNode(this.nodeRef.current) as HTMLInputElement
+    if (el) {
+      // Ports component should be positions absolute
+      // Factor this in so we get position relative to the node
+      const nodesEl = el.parentElement
+        ? el.parentElement
+        : { offsetLeft: 0, offsetTop: 0 }
+      // update port position after node size has been determined
+      this.props.onPortPositionChange({ config: this.props.config, node: this.props.node, port: this.props.port, el, nodesEl })
+    }
+  }
+
+  private portsOfType (props: IPortWrapperProps) {
+    const { port: { type }, node: { ports } } = props
+    return Object.values(ports).reduce((count, port) => port.type === type ? count + 1 : count, 0)
   }
 }


### PR DESCRIPTION
Update the position when the port is first mounted (this can happen
when the port "type" is changed e.g. from "bottom" to "right").

Also update the position when the number of ports on the port's side
changes.

Both of these updates are necessary to ensure that the links between
nodes start and end in the correct positions after an update to the
chart state.