### PR TITLE
Fix: Node size not updated when node size changed on DOM

### DIFF
--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -64,7 +64,10 @@ export const NodeWrapper = ({
   React.useLayoutEffect(() => {
     const el = ReactDOM.findDOMNode(compRef.current) as HTMLInputElement
     if (el) {
-      if (size.width !== el.offsetWidth || size.height !== el.offsetHeight) {
+      if (
+        (node.size && node.size.width) !== el.offsetWidth ||
+        (node.size && node.size.height) !== el.offsetHeight
+      ) {
         const newSize = { width: el.offsetWidth, height: el.offsetHeight }
         setSize(newSize)
         onNodeSizeChange({ config, nodeId: node.id, size: newSize })


### PR DESCRIPTION
`el.offsetWidth` and `el.offsetHeight` should be checked against `node.size.width` and `node.size.height` (which comes from `chartData`) rather then `size.width and size.height` (which is the local state).

`size.width` and `size.height` is set by `ResizeObserver`, which will always be equal with `el.offsetWidth` and `el.offsetHeight` at this place, while this side effect being triggered by `ResizeObserver`.