### PR TITLE
fix: keep data consistent w/ or w/o snapToGrid enabled

### DIFF
--- a/src/container/actions.ts
+++ b/src/container/actions.ts
@@ -16,7 +16,7 @@ export const onDragNode: IOnDragNode = ({ config, event, data, id }) => (chart: 
   if (nodechart) {
     chart.nodes[id] = {
       ...nodechart,
-      position: config && config.snapToGrid ? { x: Math.round(data.x / 20) * 20, y: Math.round(data.y / 20) * 20 } : data,
+      position: config && config.snapToGrid ? { x: Math.round(data.x / 20) * 20, y: Math.round(data.y / 20) * 20 } : { x: data.x, y: data.y },
     }
   }
 
@@ -24,7 +24,7 @@ export const onDragNode: IOnDragNode = ({ config, event, data, id }) => (chart: 
 }
 
 export const onDragCanvas: IOnDragCanvas = ({ config, event, data }) => (chart: IChart): IChart => {
-  chart.offset = config && config.snapToGrid ? { x: Math.round(data.x / 20) * 20, y: Math.round(data.y / 20) * 20 } : data
+  chart.offset = config && config.snapToGrid ? { x: Math.round(data.x / 20) * 20, y: Math.round(data.y / 20) * 20 } : { x: data.x, y: data.y }
   return chart
 }
 
@@ -172,7 +172,7 @@ export const onCanvasDrop: IOnCanvasDrop = ({ config, data, position }) => (char
   const id = v4()
   chart.nodes[id] = {
     id,
-    position: config && config.snapToGrid ? { x: Math.round(position.x / 20) * 20, y: Math.round(position.y / 20) * 20 } : position,
+    position: config && config.snapToGrid ? { x: Math.round(position.x / 20) * 20, y: Math.round(position.y / 20) * 20 } : { x: position.x, y: position.y },
     orientation: data.orientation || 0,
     type: data.type,
     ports: data.ports,


### PR DESCRIPTION
This fixes the data integrity when `snapToGrid` option is not passed. If we do not explicitly store only `x` and `y` values, browser passes some extra information such as `deltaX`, `deltaY` and `node`. Where `node` inserts a full property list of an element that is being interacted with. This creates a huge performance problem whether it is kept in internal state or external. 

In my case I pass `chart` to a redux state, and this creates circular references, and it crashes the redux devtools.

This is also mentioned in #58.
