### PR TITLE
onCanvasDrop: Support id from data argument

### DIFF
--- a/src/container/actions.ts
+++ b/src/container/actions.ts
@@ -192,7 +192,7 @@ export const onPortPositionChange: IStateCallback<IOnPortPositionChange> = ({ no
   }
 
 export const onCanvasDrop: IStateCallback<IOnCanvasDrop> = ({ config, data, position }) => (chart: IChart): IChart => {
-  const id = v4()
+  const id = data.id || v4()
   chart.nodes[id] = {
     id,
     position: config && config.snapToGrid ? { x: Math.round(position.x / 20) * 20, y: Math.round(position.y / 20) * 20 } : { x: position.x, y: position.y },


### PR DESCRIPTION
When using external state and drag&drop, it may be useful to store the new item in DB / Redux when the onCanvasDrop event is fired, but still wrap the chart with component with inner-state, and use the default "action handlers" from the libary to maintain the state.

So, with this patch we can choose the id in 
```
onDragStart={(ev) => { 
    ev.dataTransfer.setData(
        REACT_FLOW_CHART, 
        JSON.stringify({ id: chosenId, ...newNode) }
    ) 
}}
```


hope you found this helpfully,
Noy