### PR TITLE
Link Colors

### DIFF
--- a/src/components/Link/Link.default.tsx
+++ b/src/components/Link/Link.default.tsx
@@ -35,25 +35,27 @@ export const LinkDefault = ({
     !!toPort && !!matrix ? generateSmartPath(matrix, startPos, endPos, fromPort, toPort) : generateRightAnglePath(startPos, endPos)
     : generateCurvePath(startPos, endPos)
 
+  const linkColor: string = (fromPort.properties && fromPort.properties.linkColor) || 'cornflowerblue'
+
   return (
     <svg style={{ overflow: 'visible', position: 'absolute', cursor: 'pointer', left: 0, right: 0 }}>
       <circle
         r="4"
         cx={startPos.x}
         cy={startPos.y}
-        fill="cornflowerblue"
+        fill={linkColor}
       />
       {/* Main line */}
       <path
         d={points}
-        stroke="cornflowerblue"
+        stroke={linkColor}
         strokeWidth="3"
         fill="none"
       />
       {/* Thick line to make selection easier */}
       <path
         d={points}
-        stroke="cornflowerblue"
+        stroke={linkColor}
         strokeWidth="20"
         fill="none"
         strokeLinecap="round"
@@ -69,7 +71,7 @@ export const LinkDefault = ({
         r="4"
         cx={endPos.x}
         cy={endPos.y}
-        fill="cornflowerblue"
+        fill={linkColor}
       />
     </svg>
   )

--- a/stories/LinkColors.tsx
+++ b/stories/LinkColors.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react'
+
+import { FlowChartWithState, IChart } from '../src'
+import { Page } from './components'
+
+const chartSimpleWithLinkColors: IChart = {
+  offset: {
+    x: 0,
+    y: 0,
+  },
+  nodes: {
+    node1: {
+      id: 'node1',
+      type: 'output-only',
+      position: {
+        x: 300,
+        y: 100,
+      },
+      ports: {
+        port1: {
+          id: 'port1',
+          type: 'output',
+          properties: {
+            value: 'no',
+            linkColor: '#FFCC00',
+          },
+        },
+      },
+    },
+    node2: {
+      id: 'node2',
+      type: 'input-output',
+      position: {
+        x: 300,
+        y: 300,
+      },
+      ports: {
+        port1: {
+          id: 'port1',
+          type: 'input',
+        },
+        port2: {
+          id: 'port2',
+          type: 'output',
+          properties: {
+            linkColor: '#63D471',
+          },
+        },
+        port3: {
+          id: 'port3',
+          type: 'output',
+          properties: {
+            linkColor: '#F8333C',
+          },
+        },
+      },
+    },
+    node3: {
+      id: 'node3',
+      type: 'input-output',
+      position: {
+        x: 100,
+        y: 600,
+      },
+      ports: {
+        port1: {
+          id: 'port1',
+          type: 'input',
+        },
+        port2: {
+          id: 'port2',
+          type: 'output',
+        },
+      },
+    },
+    node4: {
+      id: 'node4',
+      type: 'input-output',
+      position: {
+        x: 500,
+        y: 600,
+      },
+      ports: {
+        port1: {
+          id: 'port1',
+          type: 'input',
+        },
+        port2: {
+          id: 'port2',
+          type: 'output',
+        },
+      },
+    },
+  },
+  links: {
+    link1: {
+      id: 'link1',
+      from: {
+        nodeId: 'node1',
+        portId: 'port1',
+      },
+      to: {
+        nodeId: 'node2',
+        portId: 'port1',
+      },
+    },
+    link2: {
+      id: 'link2',
+      from: {
+        nodeId: 'node2',
+        portId: 'port2',
+      },
+      to: {
+        nodeId: 'node3',
+        portId: 'port1',
+      },
+    },
+    link3: {
+      id: 'link3',
+      from: {
+        nodeId: 'node2',
+        portId: 'port3',
+      },
+      to: {
+        nodeId: 'node4',
+        portId: 'port1',
+      },
+    },
+  },
+  selected: {},
+  hovered: {},
+}
+
+export const LinkColors = () => {
+  return (
+    <Page>
+      <FlowChartWithState initialValue={chartSimpleWithLinkColors} />
+    </Page>
+  )
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
+
 import { ConfigSnapToGridDemo } from './ConfigSnapToGrid'
 import { ConfigValidateLinkDemo } from './ConfigValidateLink'
 import { CustomCanvasOuterDemo } from './CustomCanvasOuter'
@@ -10,6 +11,7 @@ import { CustomPortDemo } from './CustomPort'
 import { DragAndDropSidebar } from './DragAndDropSidebar'
 import { ExternalReactState } from './ExternalReactState'
 import { InternalReactState } from './InternalReactState'
+import { LinkColors } from './LinkColors'
 import { ReadonlyMode } from './ReadonlyMode'
 import { SelectedSidebar } from './SelectedSidebar'
 import { SmartRouting } from './SmartRouting'
@@ -25,6 +27,7 @@ storiesOf('Custom Components', module)
   .add('Port', CustomPortDemo)
   .add('Canvas Outer', CustomCanvasOuterDemo)
   .add('Canvas Link', () => <CustomLinkDemo />)
+  .add('Link Colors', () => <LinkColors />)
 
 storiesOf('Stress Testing', module).add('default', StressTestDemo)
 


### PR DESCRIPTION
Added the ability to set colors to links using the properties of the port.

```
port2: {
    id: 'port2',
    type: 'output',
    properties: {
        linkColor: '#63D471',
    },
},        
```
![Example](https://i.imgur.com/MscVnCb.png)

