### PR TITLE
Do not reset isDragging until the next mousedown.

### DIFF
--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -81,7 +81,6 @@ export const NodeWrapper = ({
   }, [onDragNode, config, node.id])
 
   const onStop = React.useCallback((event: MouseEvent, data: DraggableData) => {
-    isDragging.current = false
     onDragNodeStop({ config, event, data, id: node.id })
   }, [onDragNodeStop, config, node.id])
 


### PR DESCRIPTION
`isDragging` is meant to signify that the last action was a drag, so we should not send a click event. It should only be reset in `isStart` when the next action is started.

Fixes #131 

### Before
![flow-chart-broken](https://user-images.githubusercontent.com/785208/80537880-a0bc2180-8959-11ea-907e-081ffde856c0.gif)

### After
![flow-chart-fixed](https://user-images.githubusercontent.com/785208/80537886-a44fa880-8959-11ea-94c2-2581bea4dcb8.gif)
