### PR TITLE
Handle scaling correctly during Node movement and dropping

### DIFF
--- a/src/components/Canvas/Canvas.wrapper.tsx
+++ b/src/components/Canvas/Canvas.wrapper.tsx
@@ -137,13 +137,15 @@ export class CanvasWrapper extends React.Component<ICanvasWrapperProps, IState> 
                     e.dataTransfer.getData(REACT_FLOW_CHART),
                   )
                   if (data) {
+                    const relativeClientX = e.clientX - offsetX;
+                    const relativeClientY = e.clientY - offsetY;
                     onCanvasDrop({
                       config,
                       data,
                       position: {
-                        x: e.clientX - (position.x + offsetX),
-                        y: e.clientY - (position.y + offsetY),
-                      },
+                        x: relativeClientX / scale - position.x / scale,
+                        y: relativeClientY / scale - position.y / scale
+                      }
                     })
                   }
                 }}

--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../'
 import { noop } from '../../utils'
 import { INodeDefaultProps, NodeDefault } from './Node.default'
+import CanvasContext from "../Canvas/CanvasContext";
 
 export interface INodeWrapperProps {
   config: IConfig
@@ -67,6 +68,7 @@ export const NodeWrapper = ({
   onLinkComplete,
   onLinkCancel,
 }: INodeWrapperProps) => {
+  const { zoomScale } = React.useContext(CanvasContext);
   const [size, setSize] = React.useState<ISize>({ width: 0, height: 0 })
 
   const isDragging = React.useRef(false)
@@ -168,6 +170,7 @@ export const NodeWrapper = ({
       axis="both"
       position={node.position}
       grid={[1,1]}
+      scale={zoomScale}
       onStart={onStart}
       onDrag={onDrag}
       onStop={onStop}

--- a/src/container/actions.ts
+++ b/src/container/actions.ts
@@ -31,10 +31,16 @@ export const onDragNode: IStateCallback<IOnDragNode> = ({ config, event, data, i
   const nodechart = chart.nodes[id]
 
   if (nodechart) {
-    const position = getOffset(config, data)
+    const delta = {
+      x: data.deltaX,
+      y: data.deltaY
+    };
     chart.nodes[id] = {
       ...nodechart,
-      position,
+      position: {
+        x: nodechart.position.x + delta.x,
+        y: nodechart.position.y + delta.y
+      }
     }
   }
 


### PR DESCRIPTION
First of all, Storybook has it's on zoom controls and these do not change the scale property of the chart. So using these will break almost everything. This PR do not fix this issue.

**This PR fixes the following issue:** after changing the scale property of the chart, movement and drop of nodes won't properly reflect the position of the cursor as these do not calculate with the scale property.

**What this PR does?**
1. Sets the scale for the Draggable component used by nodes, to allow the react-draggable library to calculate with the scale property. Also uses delta for node movements, instead offset.
2. On drop, calculates using the scale property. I've also changed the order of operations a bit, as offset and position are totally different things and cannot be calculated in a single step.