### PR TITLE
Selectable mode

### DIFF
--- a/src/components/Link/Link.wrapper.tsx
+++ b/src/components/Link/Link.wrapper.tsx
@@ -5,7 +5,7 @@ import { ILinkDefaultProps, LinkDefault } from './Link.default'
 import { getLinkPosition } from './utils'
 
 export interface ILinkWrapperProps {
-  config: IConfig,
+  config: IConfig
   link: ILink
   isSelected: boolean
   isHovered: boolean
@@ -18,47 +18,47 @@ export interface ILinkWrapperProps {
   matrix?: number[][]
 }
 
-export const LinkWrapper = React.memo(({
-  config,
-  Component = LinkDefault,
-  link,
-  onLinkMouseEnter,
-  onLinkMouseLeave,
-  onLinkClick,
-  isSelected,
-  isHovered,
-  fromNode,
-  toNode,
-  matrix,
-}: ILinkWrapperProps) => {
-  const startPos = getLinkPosition(fromNode, link.from.portId)
-  const fromPort = fromNode.ports[link.from.portId]
+export const LinkWrapper = React.memo(
+  ({
+    config,
+    Component = LinkDefault,
+    link,
+    onLinkMouseEnter,
+    onLinkMouseLeave,
+    onLinkClick,
+    isSelected,
+    isHovered,
+    fromNode,
+    toNode,
+    matrix,
+  }: ILinkWrapperProps) => {
+    const startPos = getLinkPosition(fromNode, link.from.portId)
+    const fromPort = fromNode.ports[link.from.portId]
 
-  const endPos = toNode && link.to.portId
-    ? getLinkPosition(toNode, link.to.portId)
-    : link.to.position
-  const toPort = toNode && link.to.portId ? toNode.ports[link.to.portId] : undefined
+    const endPos = toNode && link.to.portId ? getLinkPosition(toNode, link.to.portId) : link.to.position
+    const toPort = toNode && link.to.portId ? toNode.ports[link.to.portId] : undefined
 
-  // Don't render the link yet if there is no end pos
-  // This will occur if the link was just created
-  if (!endPos) {
-    return null
+    // Don't render the link yet if there is no end pos
+    // This will occur if the link was just created
+    if (!endPos) {
+      return null
+    }
+
+    return (
+      <Component
+        config={config}
+        link={link}
+        matrix={matrix}
+        startPos={startPos}
+        endPos={endPos}
+        fromPort={fromPort}
+        toPort={toPort}
+        onLinkMouseEnter={config.readonly ? noop : onLinkMouseEnter}
+        onLinkMouseLeave={config.readonly ? noop : onLinkMouseLeave}
+        onLinkClick={config.readonly && !config.selectable ? noop : onLinkClick}
+        isSelected={isSelected}
+        isHovered={isHovered}
+      />
+    )
   }
-
-  return (
-    <Component
-      config={config}
-      link={link}
-      matrix={matrix}
-      startPos={startPos}
-      endPos={endPos}
-      fromPort={fromPort}
-      toPort={toPort}
-      onLinkMouseEnter={config.readonly ? noop : onLinkMouseEnter}
-      onLinkMouseLeave={config.readonly ? noop : onLinkMouseLeave}
-      onLinkClick={config.readonly ? noop : onLinkClick}
-      isSelected={isSelected}
-      isHovered={isHovered}
-    />
-  )
-})
+)

--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -111,7 +111,7 @@ export const NodeWrapper = ({
 
   const onClick = React.useCallback(
     (e: React.MouseEvent) => {
-      if (!config.readonly) {
+      if (!config.readonly || config.selectable) {
         e.stopPropagation()
         if (!isDragging.current) {
           onNodeClick({ config, nodeId: node.id })

--- a/src/container/actions.ts
+++ b/src/container/actions.ts
@@ -1,3 +1,4 @@
+import { IConfig } from 'types'
 import { v4 } from 'uuid'
 import {
   IChart,
@@ -173,7 +174,10 @@ export const onNodeMouseLeave: IStateCallback<IOnNodeMouseLeave> = ({ nodeId }) 
   return chart
 }
 
-export const onDeleteKey: IStateCallback<IOnDeleteKey> = () => (chart: IChart) => {
+export const onDeleteKey: IStateCallback<IOnDeleteKey> = ({ config }: IConfig) => (chart: IChart) => {
+  if (config.readonly) {
+    return chart
+  }
   if (chart.selected.type === 'node' && chart.selected.id) {
     const node = chart.nodes[chart.selected.id]
     if (node.readonly) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,7 @@ import { IOnLinkCompleteInput } from './functions'
 
 export interface IConfig {
   readonly?: boolean
+  selectable?: boolean
   snapToGrid?: boolean
   smartRouting?: boolean
   gridSize?: number
@@ -18,20 +19,20 @@ export interface IZoomConfig {
   maxScale?: number
   pan?: {
     disabled?: boolean
-    touchPadEnabled?: boolean,
+    touchPadEnabled?: boolean
   }
   wheel?: {
     disabled?: boolean
     step?: number
     wheelEnabled?: boolean
-    touchPadEnabled?: boolean,
+    touchPadEnabled?: boolean
   }
   zoomIn?: {
     disabled?: boolean
-    step?: number,
+    step?: number
   }
   zoomOut?: {
     disabled?: boolean
-    step?: number,
+    step?: number
   }
 }

--- a/stories/SelectableMode.tsx
+++ b/stories/SelectableMode.tsx
@@ -12,7 +12,7 @@ export const SelectableMode = () => {
 
       <Sidebar>
         <Message>
-          <strong>Selectable mode</strong> allows you to select a node when the chart is in read only mode.
+          <strong>Selectable mode</strong> allows you to select a node or link when the chart is in read only mode.
         </Message>
 
         <Message>

--- a/stories/SelectableMode.tsx
+++ b/stories/SelectableMode.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { FlowChartWithState } from '../src'
+import { Code, Content, Message, Page, Sidebar } from './components'
+import { chartSimple } from './misc/exampleChartState'
+
+export const SelectableMode = () => {
+  return (
+    <Page>
+      <Content>
+        <FlowChartWithState config={{ readonly: true, selectable: true }} initialValue={chartSimple} />
+      </Content>
+
+      <Sidebar>
+        <Message>
+          <strong>Selectable mode</strong> allows you to select a node when the chart is in read only mode.
+        </Message>
+
+        <Message>
+          You just need to pass <strong>selectable</strong> property to chart config.
+        </Message>
+        <Code>config = {JSON.stringify({ readonly: true, selectable: true }, null, 2)}</Code>
+      </Sidebar>
+    </Page>
+  )
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -13,6 +13,7 @@ import { InternalReactState } from './InternalReactState'
 import { LinkColors } from './LinkColors'
 import { NodeReadonly } from './NodeReadonly'
 import { ReadonlyMode } from './ReadonlyMode'
+import { SelectableMode } from './SelectableMode'
 import { SelectedSidebar } from './SelectedSidebar'
 import { SmartRouting } from './SmartRouting'
 import { StressTestDemo } from './StressTest'
@@ -43,3 +44,4 @@ storiesOf('Other Config', module)
   .add('Smart link routing', SmartRouting)
   .add('Zoom', () => <Zoom />)
   .add('Node read only', NodeReadonly)
+  .add('Selectable Mode', SelectableMode)


### PR DESCRIPTION
Selectable mode allows you to select a node when the chart is in read only mode.

You just need to pass selectable property to chart config.

```
config = {
  "readonly": true,
  "selectable": true
}
```

Live: https://react-flow-chart.now.sh/?path=/story/other-config--selectable-mode