### PR TITLE
Set Node minimum size based on PortGroup size

### DIFF
--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -68,6 +68,7 @@ export const NodeWrapper = ({
   onLinkCancel,
 }: INodeWrapperProps) => {
   const [size, setSize] = React.useState<ISize>({ width: 0, height: 0 })
+  const [portsSize, setPortsSize] = React.useState<ISize>({ width: 0, height: 0 })
 
   const isDragging = React.useRef(false)
 
@@ -130,7 +131,7 @@ export const NodeWrapper = ({
   }, [node, compRef.current, size.width, size.height])
 
   const children = (
-    <>
+    <div style={{ minWidth: portsSize.width, minHeight: portsSize.height }}>
       <ResizeObserver
         onResize={(rect) => {
           const newSize = { width: rect.width, height: rect.height }
@@ -138,7 +139,7 @@ export const NodeWrapper = ({
         }}
       />
       <NodeInner node={node} config={config} />
-      <Ports node={node} config={config}>
+      <Ports node={node} config={config} onResize={setPortsSize}>
         { Object.keys(node.ports).map((portId) => (
           <PortWrapper
             config={config}
@@ -159,7 +160,7 @@ export const NodeWrapper = ({
           />
         )) }
       </Ports>
-    </>
+    </div>
   )
 
   return (

--- a/src/components/Node/Node.wrapper.tsx
+++ b/src/components/Node/Node.wrapper.tsx
@@ -150,6 +150,7 @@ export const NodeWrapper = ({
             hoveredLink={hoveredLink}
             hovered={hovered}
             node={node}
+            portsSize={portsSize}
             port={node.ports[portId]}
             Component={Port}
             onPortPositionChange={onPortPositionChange}

--- a/src/components/Port/Port.wrapper.tsx
+++ b/src/components/Port/Port.wrapper.tsx
@@ -2,7 +2,7 @@ import { isEqual } from 'lodash'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { v4 } from 'uuid'
-import { IConfig, ILink, INode, IOnLinkCancel, IOnLinkComplete, IOnLinkMove, IOnLinkStart, IOnPortPositionChange, IPort, IPosition, ISelectedOrHovered } from '../../'
+import { IConfig, ILink, INode, IOnLinkCancel, IOnLinkComplete, IOnLinkMove, IOnLinkStart, IOnPortPositionChange, IPort, IPosition, ISelectedOrHovered, ISize } from '../../'
 import CanvasContext from '../Canvas/CanvasContext'
 import { IPortDefaultProps, PortDefault } from './Port.default'
 
@@ -26,6 +26,7 @@ export interface IPortWrapperProps {
   hoveredLink: ILink | undefined
   port: IPort
   node: INode
+  portsSize: ISize
   onPortPositionChange: IOnPortPositionChange
   Component: React.FunctionComponent<IPortDefaultProps>
 
@@ -49,7 +50,9 @@ export class PortWrapper extends React.Component<IPortWrapperProps> {
   public componentDidUpdate (prevProps: IPortWrapperProps) {
     // Update port position after a re-render if there are more ports on the same side
     // or if node.size has changed
-    if (this.portsOfType(this.props) !== this.portsOfType(prevProps) || !isEqual(this.props.node.size, prevProps.node.size)) {
+    if (this.portsOfType(this.props) !== this.portsOfType(prevProps)
+        || !isEqual(this.props.node.size, prevProps.node.size)
+        || !isEqual(this.props.portsSize, prevProps.portsSize)) {
       this.updatePortPosition()
     }
   }

--- a/src/components/Ports/Ports.default.tsx
+++ b/src/components/Ports/Ports.default.tsx
@@ -1,25 +1,51 @@
 import * as React from 'react'
-import { IConfig, INode, PortsGroupDefault } from '../../'
+import {IConfig, INode, ISize, PortsGroupDefault} from '../../'
+import ResizeObserver from "react-resize-observer";
+import {useEffect, useState} from "react";
 
 export interface IPortsDefaultProps {
   config: IConfig
   node: INode
   children: Array<React.ReactElement<any>>
+  onResize: (size: ISize) => void
 }
 
-export const PortsDefault = ({ children, config }: IPortsDefaultProps) => {
+export const PortsDefault = ({ children, config, onResize }: IPortsDefaultProps) => {
+  const [ top, setTop ] = useState(0);
+  const [ bottom, setBottom ] = useState(0);
+  const [ right, setRight ] = useState(0);
+  const [ left, setLeft ] = useState(0);
+  const [ width, setWidth ] = useState(0);
+  const [ height, setHeight ] = useState(0);
+
+  useEffect(() => {
+    setWidth(Math.max(top, bottom))
+  }, [ top, bottom ]);
+
+  useEffect(() => {
+    setHeight(Math.max(left, right))
+  }, [ left, right ]);
+
+  useEffect(() => {
+    onResize({ width, height })
+  }, [ width, height, onResize ]);
+
   return (
     <div>
       <PortsGroupDefault config={config} side="top">
+        <ResizeObserver onResize={(rect) => { setTop(rect.width) }} />
         {children.filter((child) => ['input', 'top'].includes(child.props.port.type))}
       </PortsGroupDefault>
       <PortsGroupDefault config={config} side="bottom">
+        <ResizeObserver onResize={(rect) => { setBottom(rect.width) }} />
         {children.filter((child) => ['output', 'bottom'].includes(child.props.port.type))}
       </PortsGroupDefault>
       <PortsGroupDefault config={config} side="right">
+        <ResizeObserver onResize={(rect) => { setRight(rect.height) }} />
         {children.filter((child) => ['right'].includes(child.props.port.type))}
       </PortsGroupDefault>
       <PortsGroupDefault config={config} side="left">
+        <ResizeObserver onResize={(rect) => { setLeft(rect.height) }} />
         {children.filter((child) => ['left'].includes(child.props.port.type))}
       </PortsGroupDefault>
     </div>

--- a/src/components/PortsGroup/PortsGroup.default.tsx
+++ b/src/components/PortsGroup/PortsGroup.default.tsx
@@ -14,7 +14,7 @@ export const PortsGroupDefault = styled.div<IPortsGroupDefaultProps>`
   ${(props) => {
     if (props.side === 'top') {
       return css`
-        width: 100%;
+        min-width: 100%;
         left: 0;
         top: -12px;
         flex-direction: row;
@@ -24,7 +24,7 @@ export const PortsGroupDefault = styled.div<IPortsGroupDefaultProps>`
       `
     } else if (props.side === 'bottom') {
       return css`
-        width: 100%;
+        min-width: 100%;
         left: 0;
         bottom: -12px;
         flex-direction: row;
@@ -34,7 +34,7 @@ export const PortsGroupDefault = styled.div<IPortsGroupDefaultProps>`
       `
     } else if (props.side === 'left') {
       return css`
-        height: 100%;
+        min-height: 100%;
         top: 0;
         left: -12px;
         flex-direction: column;
@@ -44,7 +44,7 @@ export const PortsGroupDefault = styled.div<IPortsGroupDefaultProps>`
       `
     } else {
       return css`
-        height: 100%;
+        min-height: 100%;
         top: 0;
         right: -12px;
         flex-direction: column;


### PR DESCRIPTION
Use react-resize-observer in Ports and notify the Node about size changes. In Node, set the minimum size (minWidth and minHeight css props) based on the size of Ports. Size of Ports is calculated from max(top.width, bottom.width) and max(left.height, right.height).

This way node size is still calculated based on NodeInner's size, but cannot be smaller than the minimal size specified by the ports. Also this magically solves the issue with Links getting rendered at the wrong place when PortGroup is larger than the side of the Node (as it won't be larger ever).