### PR TITLE
Fix for onCanvasDrop creating two nodes

### DIFF
--- a/src/components/Canvas/Canvas.wrapper.tsx
+++ b/src/components/Canvas/Canvas.wrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { v4 } from 'uuid'
 import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch'
 import { IConfig, IOnCanvasClick, IOnCanvasDrop, IOnDeleteKey, IOnDragCanvas, IOnDragCanvasStop, IOnZoomCanvas, REACT_FLOW_CHART } from '../../'
 import CanvasContext from './CanvasContext'
@@ -144,6 +145,7 @@ export class CanvasWrapper extends React.Component<ICanvasWrapperProps, IState> 
                         x: e.clientX - (position.x + offsetX),
                         y: e.clientY - (position.y + offsetY),
                       },
+                      id: data.id || v4(),
                     })
                   }
                 }}

--- a/src/container/actions.ts
+++ b/src/container/actions.ts
@@ -1,4 +1,3 @@
-import { v4 } from 'uuid'
 import {
   IChart, identity, IOnCanvasClick,
   IOnCanvasDrop, IOnDeleteKey, IOnDragCanvas, IOnDragCanvasStop,
@@ -233,8 +232,8 @@ export const onCanvasDrop: IStateCallback<IOnCanvasDrop> = ({
   config,
   data,
   position,
+  id,
 }) => (chart: IChart): IChart => {
-  const id = data.id || v4()
   chart.nodes[id] = {
     id,
     position:

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -110,6 +110,7 @@ export interface IOnCanvasDropInput {
   config?: IConfig
   data: any
   position: IPosition
+  id: string
 }
 
 export type IOnCanvasDrop = (input: IOnCanvasDropInput) => void


### PR DESCRIPTION
This should fix the bug where onCanvasDrop creates two nodes in development.

Should fix #122 & #161 