### PR TITLE
Add missing required property on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ const chartSimple = {
     x: 0,
     y: 0
   },
+  scale: 1,
   nodes: {
     node1: {
       id: "node1",


### PR DESCRIPTION
The example on the README was failing with Typescript because `scale` was not set. 

```
Error:(79, 25) TS2322: Type '{ offset: { x: number; y: number; }; nodes: { node1: { id: string; type: string; position: { x: number; y: number; }; ports: { port1: { id: string; type: string; properties: { value: string; }; }; port2: { id: string; type: string; properties: { ...; }; }; }; }; node2: { ...; }; }; links: { ...; }; selected: {}; hov...' is not assignable to type 'IChart<undefined, undefined, undefined, undefined>'.
  Property 'scale' is missing in type '{ offset: { x: number; y: number; }; nodes: { node1: { id: string; type: string; position: { x: number; y: number; }; ports: { port1: { id: string; type: string; properties: { value: string; }; }; port2: { id: string; type: string; properties: { ...; }; }; }; }; node2: { ...; }; }; links: { ...; }; selected: {}; hov...' but required in type '{ offset: IPosition; nodes: { [id: string]: INode<undefined, undefined>; }; links: { [id: string]: ILink<undefined>; }; scale: number; selected: ISelectedOrHovered; hovered: ISelectedOrHovered; }'.
```